### PR TITLE
Feature describe model

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,6 @@
     "python.linting.enabled": true,
     "python.linting.pylintArgs": [
         "--disable",
-        "E0402",  // relative-beyond-top-level
+        "E0402 R903", // relative-beyond-top-level, too-few-public-methods
     ]
 }

--- a/credmark/credmark_dev.py
+++ b/credmark/credmark_dev.py
@@ -20,7 +20,6 @@ from .types.dto import (
     print_example,
     print_tree,
     dto_schema_viz,
-    cross_examples,
 )
 
 logger = logging.getLogger(__name__)
@@ -103,7 +102,8 @@ def main():
     parser_run.set_defaults(func=run_model, depth=0)
 
     parser_build = subparsers.add_parser(
-        'build', help='Build model manifest [Not required during development]', aliases=['build-manifest'])
+        'build', help='Build model manifest [Not required during development]',
+        aliases=['build-manifest'])
     parser_build.set_defaults(func=write_manifest_file)
 
     parser_clean = subparsers.add_parser(

--- a/credmark/credmark_dev.py
+++ b/credmark/credmark_dev.py
@@ -15,7 +15,12 @@ from .model.errors import MaxModelRunDepthError, MissingModelError, \
     ModelRunError, ModelRunRequestError
 from .model.web3 import Web3Registry
 from .model.encoder import json_dump
-from .types.dto import cross_examples
+from .types.dto import (
+    print_example,
+    print_tree,
+    dto_schema_viz,
+    cross_examples,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +49,8 @@ def main():
     parser_list = subparsers.add_parser('list', help='List models', aliases=['list-models'])
     parser_list.add_argument('--manifests', action='store_true', default=False)
     parser_list.add_argument('--json', action='store_true', default=False)
+    parser_list.add_argument('model-slug', nargs='?', default=None, type=str,
+                             help='Slug to describe.')
     parser_list.set_defaults(func=list_models)
 
     parser_list = subparsers.add_parser(
@@ -108,117 +115,10 @@ def load_models(args):
     return model_loader
 
 
-def drill_definition(head_node, var_name, node, n_iter, ret_type):
-    assert ret_type in ['tree', 'example']
-    try:
-        # 1. DTO/dict
-        # 1.1 DTO with example
-        # 1.2 DTO without example
-        # 1.3 dict
-        # 2. Array
-        # 2.1 DTO
-        # 2.2 other
-        # 3. Union
-        # 4. DTO Reference
-
-        if 'type' in node:
-            if node['type'] == 'object':
-                # DTO with example
-                if ret_type == 'example' and 'examples' in node:
-                    return node["examples"]
-                # DTO without example
-                if 'properties' in node:
-                    props = node['properties']
-                    required = node['required'] if 'required' in node else list(props.keys())
-                    ret = []
-                    for prop_name, prop_item in props.items():
-                        if prop_name in required:
-                            if ret_type == 'tree':
-                                ret.extend(drill_definition(
-                                    head_node, prop_name, prop_item, n_iter + 1, ret_type))
-                            elif ret_type == 'example':
-                                drill_ret = drill_definition(
-                                    head_node, prop_name, prop_item, n_iter + 1, ret_type)
-                                if len(ret) == 0:
-                                    ret = drill_ret
-                                else:
-                                    ret = cross_examples(ret, drill_ret, limit=10)
-                    return ret
-
-                # dict
-                if ret_type == 'tree':
-                    return [(n_iter, 'dict()')]
-                return [{var_name: {}}]
-
-            if node['type'] == 'array':
-                # array of object
-                if '$ref' in node['items']:
-                    ref = node['items']['$ref'].split('/')
-                    definition_node = head_node[ref[1]][ref[2]]
-                    ret = drill_definition(head_node, var_name,
-                                           definition_node, n_iter + 1, ret_type)
-                    if ret_type == 'tree':
-                        return [(n_iter, f'List[{var_name}]')] + ret
-                    return [{var_name: [ret]}]
-
-                # array of other type
-                if 'type' in node['items']:
-                    if ret_type == 'tree':
-                        return [(n_iter, f'List[{node["items"]["type"]}]')]
-                    return [{var_name: node["items"]['type']}]
-                else:
-                    raise ValueError(f'Unhandled {node}')
-            else:  # ['type'] != 'array'
-                # ordinary type
-                if ret_type == 'tree':
-                    return [(n_iter, node["type"])]
-                return [{var_name: node["type"]}]
-
-        # Various Union type
-        elif 'anyOf' in node or 'allOf' in node or 'oneOf' in node:
-            ret = []
-            of_node = node.get('anyOf', node.get('allOf', node.get('oneOf')))
-            for item in of_node:
-                if ret_type == 'tree':
-                    ret.extend(drill_definition(
-                        head_node, var_name, item, n_iter + 1, ret_type))
-                elif ret_type == 'example':
-                    drill_ret = drill_definition(
-                        head_node, var_name, item, n_iter + 1, ret_type)
-                    if len(ret) == 0:
-                        ret = drill_ret
-                    else:
-                        ret = cross_examples(ret, drill_ret, limit=10)
-            return ret
-
-        # Object reference
-        elif '$ref' in node:
-            ref = node['$ref'].split('/')
-            definition_node = head_node[ref[1]][ref[2]]
-            breakpoint()
-            return drill_definition(head_node, var_name, definition_node, n_iter + 1, ret_type)
-        else:
-            raise ValueError(f'Unhandled {node}')
-    except Exception as err:
-        raise ValueError(f'Unknown schema node {var_name, node, err}')
-
-
-def print_tree(v):
-    if isinstance(v, tuple):
-        nn, cc = v
-        print(f'{" "*4*nn}{cc}')
-    elif isinstance(v, list):
-        for x in v:
-            print_tree(x)
-    elif isinstance(v, dict):
-        for kk, vv in v.items():
-            print(f'{kk}: {print_tree(vv)}')
-        raise ValueError(v)
-
-
 def describe_models(args, ):
     args['manifests'] = True
     args['json'] = False
+    args['describe'] = True
     list_models(args)
 
 
@@ -228,6 +128,7 @@ def list_models(args):
     model_loader = load_models(args)
     json_output = args.get('json')
     model_slug = args.get('model-slug')
+    is_describe = args.get('describe', False)
 
     if not json_output:
         sys.stdout.write('\nLoaded models:\n\n')
@@ -241,37 +142,40 @@ def list_models(args):
         else:
             # add more tree-descriptive
             for m in manifests:
-                # breakpoint()
-                try:
-                    print(m['slug'], ":")
-                    print(m['input'], ":")
-                    print()
-
-                    head_node = m['input']
-                    tree_schema = drill_definition(
-                        head_node, head_node['title'], head_node, 0, 'tree')
-                    examples = drill_definition(
-                        head_node, head_node['title'], head_node, 0, 'example')
-
-                    print('example:')
-                    if len(examples) > 0:
-                        for n, l in enumerate(examples):
-                            print(f'#{n+1:02d}: {l}')
+                for i, v in m.items():
+                    if i == 'slug':
+                        sys.stdout.write(f' - {i}: {v}\n')
                     else:
-                        print('Nil')
+                        if not is_describe:
+                            sys.stdout.write(f' - {i}: {v}\n')
+                        else:
+                            if i == 'input':
+                                input_tree = dto_schema_viz(
+                                    v, v['title'], v, 0, 'tree', 10)
+                                input_examples = dto_schema_viz(
+                                    v, v['title'], v, 0, 'example', 10)
 
-                    print('tree_schema:')
-                    if len(tree_schema) > 0:
-                        print_tree(tree_schema)
-                    else:
-                        print('Nil')
-                    print(tree_schema)
+                                print(' - input schema:')
+                                print_tree(input_tree, '   ', sys.stdout.write)
 
-                except Exception as err:
-                    raise err
+                                print(' - input example:')
+                                print_example(input_examples, '   ', sys.stdout.write)
 
-                # for i, v in m.items():
-                #    sys.stdout.write(f' {i}: {v}\n')
+                            elif i == 'output':
+                                output_tree = dto_schema_viz(
+                                    v, v['title'], v, 0, 'tree', 1)
+                                output_examples = dto_schema_viz(
+                                    v, v['title'], v, 0, 'example', 1)
+
+                                print(' - output schema:')
+                                print_tree(output_tree, '   ', sys.stdout.write)
+
+                                print(' - output example:')
+                                print_example(output_examples, '   ', sys.stdout.write)
+
+                            else:
+                                sys.stdout.write(f' - {i}: {v}\n')
+
                 sys.stdout.write('\n')
     else:
         models = model_loader.loaded_model_version_lists()

--- a/credmark/credmark_dev.py
+++ b/credmark/credmark_dev.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import json
 from typing import (
+    List,
     Union,
 )
 
@@ -40,14 +41,14 @@ def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description='Credmark developer tool')
-    parser.add_argument('--log_level', default='INFO', required=False,
+    parser.add_argument('--log_level', default=None, required=False,
                         help='Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL')
     parser.add_argument('--model_path', default="models", required=False,
                         help='Semicolon separated paths to the model folders \
                             (or parent) or model python file. Defaults to models folder.')
     parser.add_argument('--manifest_file', type=str, default='models.json',
                         help='Name of the built manifest file. Defaults to models.json. '
-                        '(Not required during development.)')
+                        '[Not required during development]')
 
     subparsers = parser.add_subparsers(title='Commands',
                                        description='Supported commands',
@@ -63,14 +64,8 @@ def main():
                              help='[OPTIONAL] Slug for the model to show.')
     parser_list.set_defaults(func=list_models)
 
-    parser_list = subparsers.add_parser(
-        'describe', help='describe models', aliases=['describe-models'])
-    parser_list.add_argument('model-slug', nargs='?', default=None, type=str,
-                             help='Slug to describe.')
-    parser_list.set_defaults(func=describe_models)
-
     parser_models = subparsers.add_parser(
-        'deployed', help='List deployed models on server', aliases=['deployed-models'])
+        'models', help='List models deployed on server', aliases=['deployed-models'])
     parser_models.add_argument('--manifests', action='store_true', default=False,
                                help="Show full manifests")
     parser_models.add_argument('--json', action='store_true',
@@ -79,6 +74,13 @@ def main():
                                help='[OPTIONAL] Slug for the model to show.')
     add_api_url_arg(parser_models)
     parser_models.set_defaults(func=list_deployed_models)
+
+    parser_list = subparsers.add_parser(
+        'describe', help='Show documentation for local and deployed models', aliases=['describe-models', 'man'])
+    parser_list.add_argument('model-slug', nargs='?', default=None, type=str,
+                             help='Slug or partial slug to describe.')
+    add_api_url_arg(parser_list)
+    parser_list.set_defaults(func=describe_models)
 
     parser_run = subparsers.add_parser('run', help='Run a model', aliases=['run-model'])
     parser_run.add_argument('-b', '--block_number', type=int, required=False, default=None,
@@ -118,10 +120,13 @@ def main():
     args.func(vars(args))
 
 
-def config_logging(args):
+def config_logging(args, default_level='WARNING'):
+    level = args['log_level']
+    if not level:
+        level = default_level
     logging.basicConfig(
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        level=args['log_level'])
+        level=level)
 
 
 def load_models(args, load_dev_models=False):
@@ -134,10 +139,36 @@ def load_models(args, load_dev_models=False):
 
 
 def describe_models(args, ):
-    args['manifests'] = True
-    args['json'] = False
-    args['describe'] = True
-    list_models(args)
+    config_logging(args)
+    model_api = create_model_api(args)
+    model_loader = load_models(args, True)
+
+    manifests = model_loader.loaded_model_manifests()
+    try:
+        deployed_manifests = model_api.get_models()
+    except Exception:
+        # Error will have been logged but we continue
+        # so things work offline
+        deployed_manifests = []
+
+    manifests = merge_manifests(manifests, deployed_manifests)
+
+    model_slug = args.get('model-slug')
+    if model_slug is not None:
+        manifests = [m for m in manifests if model_slug in m['slug']]
+
+    print('')
+    if len(manifests) > 0:
+        print_manifests(manifests, True)
+    else:
+        print_no_models_found(model_slug)
+
+
+def print_no_models_found(model_slug):
+    if model_slug:
+        print(f'No models matching slug {model_slug}')
+    else:
+        print('No models found')
 
 
 def list_models(args):
@@ -146,7 +177,6 @@ def list_models(args):
     model_loader = load_models(args, True)
     json_output = args.get('json')
     model_slug = args.get('model-slug')
-    is_describe = args.get('describe', False)
 
     if not json_output:
         sys.stdout.write('\nLoaded models:\n\n')
@@ -158,43 +188,10 @@ def list_models(args):
         if json_output:
             json.dump({'models': manifests}, sys.stdout)
         else:
-            # add more tree-descriptive
-            for m in manifests:
-                for i, v in m.items():
-                    if i == 'slug':
-                        sys.stdout.write(f' - {i}: {v}\n')
-                    else:
-                        if not is_describe:
-                            sys.stdout.write(f' - {i}: {v}\n')
-                        else:
-                            if i == 'input':
-                                input_tree = dto_schema_viz(
-                                    v, v['title'], v, 0, 'tree', 10)
-                                input_examples = dto_schema_viz(
-                                    v, v['title'], v, 0, 'example', 10)
-
-                                print(' - input schema:')
-                                print_tree(input_tree, '   ', sys.stdout.write)
-
-                                print(' - input example:')
-                                print_example(input_examples, '   ', sys.stdout.write)
-
-                            elif i == 'output':
-                                output_tree = dto_schema_viz(
-                                    v, v['title'], v, 0, 'tree', 1)
-                                output_examples = dto_schema_viz(
-                                    v, v['title'], v, 0, 'example', 1)
-
-                                print(' - output schema:')
-                                print_tree(output_tree, '   ', sys.stdout.write)
-
-                                print(' - output example:')
-                                print_example(output_examples, '   ', sys.stdout.write)
-
-                            else:
-                                sys.stdout.write(f' - {i}: {v}\n')
-
-                sys.stdout.write('\n')
+            if len(manifests) > 0:
+                print_manifests(manifests)
+            else:
+                print_no_models_found(model_slug)
     else:
         models = model_loader.loaded_model_version_lists()
         if model_slug is not None:
@@ -205,8 +202,11 @@ def list_models(args):
         else:
             slugs = list(models.keys())
             slugs.sort()
-            for s in slugs:
-                sys.stdout.write(f' - {s}: {models[s]}\n')
+            if len(slugs) > 0:
+                for s in slugs:
+                    sys.stdout.write(f' - {s}: {models[s]}\n')
+            else:
+                print_no_models_found(model_slug)
 
     if not json_output:
         sys.stdout.write('\n')
@@ -215,13 +215,30 @@ def list_models(args):
     sys.exit(0)
 
 
+def create_model_api(args):
+    api_url = args.get('api_url')
+    return ModelApi(api_url)
+
+
+def merge_manifests(manifests: List[dict], extra_manifests: List[dict]):
+    """
+    We copy the list because it may be owned by the model_loader.
+    """
+    merged = manifests.copy()
+    slugs = {m['slug'] for m in merged}
+    for m in extra_manifests:
+        if not m['slug'] in slugs:
+            merged.append(m)
+    merged.sort(key=lambda m: m['slug'])
+    return merged
+
+
 def list_deployed_models(args):
     config_logging(args)
     json_output = args.get('json')
     model_slug = args.get('model-slug')
     show_manifests = args.get('manifests') or model_slug
-    api_url = args.get('api_url')
-    model_api = ModelApi(api_url)
+    model_api = create_model_api(args)
 
     if model_slug:
         model = model_api.get_model(model_slug)
@@ -230,42 +247,72 @@ def list_deployed_models(args):
             if deployments:
                 model['versions'] = {
                     dep["version"]: dep.get("location", "") for dep in deployments}
-            models = [model]
+            manifests = [model]
         else:
-            models = []
+            manifests = []
     else:
-        models = model_api.get_models()
+        manifests = model_api.get_models()
 
     if not json_output:
         if model_slug:
             sys.stdout.write('\n')
-            if len(models) == 0:
+            if len(manifests) == 0:
                 sys.stdout.write(f'Model slug {model_slug} not found on server.\n\n')
         else:
             sys.stdout.write('\nDeployed Models:\n\n')
 
         if show_manifests:
-            for model in models:
-                print('slug:', model['slug'])
-                versions = model.get('versions')
-                if versions:
-                    print('versions:', versions)
-                print('displayName:', model.get('displayName'))
-                print('description:', model.get('description'))
-                print('developer:', model.get('developer'))
-                print('input:', model.get('input'))
-                print('output:', model.get('output'))
-                print('')
+            print_manifests(manifests)
         else:
-            for model in models:
+            for model in manifests:
                 print(f'{model["slug"]} : {model.get("displayName", "")}')
             print('')
     else:
-        json.dump(models, sys.stdout)
+        json.dump(manifests, sys.stdout)
+
+
+def print_manifests(manifests: List[dict], describe_schemas=False):
+    for m in manifests:
+        for i, v in m.items():
+            if i == 'slug':
+                sys.stdout.write(f'{v}\n')
+                sys.stdout.write(f' - {i}: {v}\n')
+            else:
+                if not describe_schemas:
+                    sys.stdout.write(f' - {i}: {v}\n')
+                else:
+                    if i == 'input':
+                        input_tree = dto_schema_viz(
+                            v, v.get('title', 'Object'), v, 0, 'tree', 10)
+                        input_examples = dto_schema_viz(
+                            v, v.get('title', 'Object'), v, 0, 'example', 10)
+
+                        print(' - input schema:')
+                        print_tree(input_tree, '   ', sys.stdout.write)
+
+                        print(' - input example:')
+                        print_example(input_examples, '   ', sys.stdout.write)
+
+                    elif i == 'output':
+                        output_tree = dto_schema_viz(
+                            v, v.get('title', 'Object'), v, 0, 'tree', 1)
+                        output_examples = dto_schema_viz(
+                            v, v.get('title', 'Object'), v, 0, 'example', 1)
+
+                        print(' - output schema:')
+                        print_tree(output_tree, '   ', sys.stdout.write)
+
+                        print(' - output example:')
+                        print_example(output_examples, '   ', sys.stdout.write)
+
+                    else:
+                        sys.stdout.write(f' - {i}: {v}\n')
+
+        sys.stdout.write('\n')
 
 
 def write_manifest_file(args):
-    config_logging(args)
+    config_logging(args, 'INFO')
     model_loader = load_models(args)
     model_loader.write_manifest_file()
     sys.exit(0)
@@ -282,7 +329,7 @@ def run_model(args):
     exit_code = 0
 
     try:
-        config_logging(args)
+        config_logging(args, 'INFO')
 
         chain_to_provider_url = None
         providers_json = args['provider_url_map']

--- a/credmark/model/engine/model_api.py
+++ b/credmark/model/engine/model_api.py
@@ -48,13 +48,13 @@ class ModelApi:
                 f'Error running api request for {url}: {err}')
             raise
         except Exception as err:
-            logger.error(
-                f'Error running api request for {url}: {err}')
             if resp is not None:
                 if resp.status_code == 404:
                     return None
                 else:
                     logger.error(f'Error api response {resp.text}')
+            logger.error(
+                f'Error running api request for {url}: {err}')
             raise
         finally:
             # Ensure the response is closed in case we ever don't

--- a/credmark/model/utils/historical_util.py
+++ b/credmark/model/utils/historical_util.py
@@ -1,7 +1,11 @@
 from typing import Type, TypeVar, Union
 import credmark.model
 from credmark.model.errors import ModelRunError
-from credmark.types import BlockSeries, SeriesModelStartEndIntervalInput, SeriesModelWindowIntervalInput
+from credmark.types import (
+    BlockSeries,
+    SeriesModelStartEndIntervalInput,
+    SeriesModelWindowIntervalInput,
+)
 from credmark.types.dto import DTO
 
 DTOCLS = TypeVar('DTOCLS')

--- a/credmark/types/__init__.py
+++ b/credmark/types/__init__.py
@@ -1,4 +1,4 @@
-# pylint disable=unused-imports
+# pylint: disable=locally-disabled, unused-import
 
 from .data.address import Address, NULL_ADDRESS
 from .data.block_number import BlockNumber

--- a/credmark/types/data/account.py
+++ b/credmark/types/data/account.py
@@ -1,5 +1,5 @@
 from typing import List
-from .address import Address, NULL_ADDRESS
+from .address import Address
 from ..dto import DTO, DTOField, PrivateAttr, IterableListGenericDTO
 
 
@@ -8,11 +8,7 @@ class Account(DTO):
 
     class Config:
         schema_extra = {
-            'example': [
-                {
-                    'address': NULL_ADDRESS,
-                }
-            ]
+            'examples': [{'address': '0x1F98431c8aD98523631AE4a59f267346ea31F984', }]
         }
 
 
@@ -20,4 +16,3 @@ class Accounts(IterableListGenericDTO[Account]):
     accounts: List[Account] = DTOField(
         default=[], description="A list of Accounts")
     _iterator: str = PrivateAttr('accounts')
-

--- a/credmark/types/data/address.py
+++ b/credmark/types/data/address.py
@@ -19,6 +19,7 @@ def validate_address(addr: str):
 
 evm_address_regex = re.compile(r'^0x[a-fA-F0-9]{40}$')
 
+
 class Address(str):
     """
     An EVM address which is a lowercase hex string.
@@ -101,9 +102,6 @@ class Address(str):
     def checksum(self):
         return self._checksum
 
-    @staticmethod
-    def example():
-        return { 'address': '0x0000000000000000000000000000000000000000',}
 
 NULL_ADDRESS = Address("0x0000000000000000000000000000000000000000")
 

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -7,9 +7,8 @@ from typing import (
 from web3.contract import Contract as Web3Contract
 
 import credmark.model
-from credmark.types.data.account import Account, NULL_ADDRESS
+from credmark.types.data.account import Account
 from credmark.types.dto import PrivateAttr, IterableListGenericDTO, DTOField
-
 
 
 class Contract(Account):
@@ -26,9 +25,11 @@ class Contract(Account):
         arbitrary_types_allowed = True
         underscore_attrs_are_private = True
         schema_extra = {
-            'example': { 'address': NULL_ADDRESS, }
+            'examples': Account.Config.schema_extra['examples'] +
+            [{'address': '0x1F98431c8aD98523631AE4a59f267346ea31F984',
+              'abi': '(Optional) contract abi JSON string'
+             }]
         }
-
 
     def __init__(self, **data):
         if isinstance(data.get('abi'), str):

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -28,7 +28,7 @@ class Contract(Account):
             'examples': Account.Config.schema_extra['examples'] +
             [{'address': '0x1F98431c8aD98523631AE4a59f267346ea31F984',
               'abi': '(Optional) contract abi JSON string'
-             }]
+              }]
         }
 
     def __init__(self, **data):

--- a/credmark/types/data/portfolio.py
+++ b/credmark/types/data/portfolio.py
@@ -1,8 +1,34 @@
 from typing import List
-from ..dto import DTOField, PrivateAttr, IterableListGenericDTO
+from ..dto import (
+    DTO,
+    DTOField,
+    PrivateAttr,
+    IterableListGenericDTO,
+    cross_examples
+)
+from .account import Account
+from .address import Address
+from .price import Price
+
 from .position import Position
 
 
 class Portfolio(IterableListGenericDTO[Position]):
     positions: List[Position] = DTOField(default=[], description='List of positions')
     _iterator: str = PrivateAttr('positions')
+
+    class Config:
+        schema_extra: dict = {
+            'examples': [{'positions': Position.Config.schema_extra['examples']}, ]
+        }
+
+
+class PriceList(DTO):
+    price: Price
+    token: Address
+
+    class Config:
+        schema_extra: dict = {
+            'examples': cross_examples(Price.Config.schema_extra['examples'],
+                                       Account.Config.schema_extra['examples'])
+        }

--- a/credmark/types/data/portfolio.py
+++ b/credmark/types/data/portfolio.py
@@ -19,7 +19,7 @@ class Portfolio(IterableListGenericDTO[Position]):
 
     class Config:
         schema_extra: dict = {
-            'examples': [{'positions': Position.Config.schema_extra['examples']}, ]
+            'examples': [{'positions': [exp]} for exp in Position.Config.schema_extra['examples']]
         }
 
 

--- a/credmark/types/data/position.py
+++ b/credmark/types/data/position.py
@@ -1,10 +1,17 @@
-from ..dto import DTO, DTOField
+from ..dto import DTO, DTOField, cross_examples
 from ..data.token import Token
 
 
 class Position(DTO):
     amount: float = DTOField(0.0, description='Quantity of token held')
     token: Token = DTOField(..., description='Token')
+
+    class Config:
+        schema_extra = {
+            'examples': cross_examples([{'amount': '4.2', }],
+                                       Token.Config.schema_extra['examples'],
+                                       limit=10)
+        }
 
     def value_usd(self):
         # TODO: Figure out for non-ERC20 Tokens

--- a/credmark/types/data/price.py
+++ b/credmark/types/data/price.py
@@ -5,9 +5,19 @@ from ..data.token import Token
 class Price(DTO):
     price: float = DTOField(0.0, description='Value of one Token')
 
+    class Config:
+        schema_extra: dict = {
+            'examples': [{'price': 4.2}]
+        }
+
 
 class TokenPairPrice(Price):
     token: Token = DTOField(..., description='Token')
     reference_token: Token = DTOField(
         default_factory=lambda: Token(symbol="USDC"),
         description='The token as the reference price (Defaults to USDC)')
+
+    class Config:
+        schema_extra: dict = {
+            'examples': [{'token': Token.Config.schema_extra['examples']}]
+        }

--- a/credmark/types/data/token.py
+++ b/credmark/types/data/token.py
@@ -1,5 +1,4 @@
 
-from email.policy import default
 import credmark.model
 import credmark.types
 from .contract import Contract
@@ -16,12 +15,19 @@ class Token(Contract):
     # TODO: Decimals are only available in erc20s, not erc721 or erc1155
     decimals: Union[int, None]
 
+    class Config:
+        schema_extra = {
+            'examples': [{'symbol': 'USDC'},
+                         {'symbol': 'USDC', 'decimals': 6}
+                         ] + Contract.Config.schema_extra['examples']
+        }
+
     def __init__(self, **data):
 
         if 'symbol' not in data or \
-            'decimals' not in data or \
-            'address' not in data or \
-                'name' not in data:
+           'decimals' not in data or \
+           'address' not in data or \
+           'name' not in data:
             context = credmark.model.ModelContext.current_context
             if context is None:
                 raise ValueError(f'No current context to look up missing token data {data}')
@@ -81,7 +87,8 @@ class Token(Contract):
         context = credmark.model.ModelContext.current_context
         if context is None:
             raise ValueError(f'No current context to get price of token {self.symbol}')
-        return context.run_model(CoreModels.token_price, self, return_type=credmark.types.Price).price
+        return context.run_model(CoreModels.token_price, self,
+                                 return_type=credmark.types.Price).price
 
 
 class Tokens(IterableListGenericDTO[Token]):

--- a/credmark/types/dto.py
+++ b/credmark/types/dto.py
@@ -18,10 +18,23 @@ from pydantic.generics import GenericModel as GenericDTO
 
 from abc import abstractproperty
 
+from itertools import product
+
 
 def fixstr(fixed_length):
     return constr(min_length=fixed_length,
                   max_length=fixed_length)
+
+
+def combine_dict(dicts):
+    dd = {}
+    for d in dicts:
+        dd |= d
+    return dd
+
+
+def cross_examples(*x, limit=10):
+    return [combine_dict(ds) for ds in product(*x)][:limit]
 
 
 class HexStr(str):

--- a/credmark/types/dto.py
+++ b/credmark/types/dto.py
@@ -18,23 +18,17 @@ from pydantic.generics import GenericModel as GenericDTO
 
 from abc import abstractproperty
 
-from itertools import product
+from .dto_schema import (
+    cross_examples,
+    dto_schema_viz,
+    print_tree,
+    print_example,
+)
 
 
 def fixstr(fixed_length):
     return constr(min_length=fixed_length,
                   max_length=fixed_length)
-
-
-def combine_dict(dicts):
-    dd = {}
-    for d in dicts:
-        dd |= d
-    return dd
-
-
-def cross_examples(*x, limit=10):
-    return [combine_dict(ds) for ds in product(*x)][:limit]
 
 
 class HexStr(str):

--- a/credmark/types/dto_schema.py
+++ b/credmark/types/dto_schema.py
@@ -12,6 +12,7 @@ def cross_examples(*x, limit=10):
     return [combine_dict(ds) for ds in product(*x)][:limit]
 
 
+#  -> Union[Iterable[Tuple[Any, Any, Any]], Iterable[Dict[str, str]]]
 def dto_schema_viz(head_node, var_name, node, n_iter, ret_type, limit=10):
     assert ret_type in ['tree', 'example']
     try:
@@ -45,8 +46,9 @@ def dto_schema_viz(head_node, var_name, node, n_iter, ret_type, limit=10):
                             if ret_type == 'tree':
                                 if len(ret) == 1:
                                     ret = [(n_iter, var_name, node['type'])]
-                                ret.extend(dto_schema_viz(
-                                    head_node, prop_name, prop_item, n_iter + 1, ret_type, limit))
+                                drill_ret = dto_schema_viz(
+                                    head_node, prop_name, prop_item, n_iter + 1, ret_type, limit)
+                                ret.extend(drill_ret)
                             elif ret_type == 'example':
                                 drill_ret = dto_schema_viz(
                                     head_node, prop_name, prop_item, n_iter + 1, ret_type, limit)
@@ -95,12 +97,18 @@ def dto_schema_viz(head_node, var_name, node, n_iter, ret_type, limit=10):
                     if len(ret) == 0:
                         ret = drill_ret
                     else:
-                        ret[0] = (ret[0][0], ret[0][1] + ' | ' + drill_ret[1])
+                        ret[0] = (ret[0][0], ret[0][1], ret[0][2] + ' | ' + drill_ret[0][2])
                 elif ret_type == 'example':
                     if len(ret) == 0:
                         ret = drill_ret
                     else:
-                        ret = cross_examples(ret, drill_ret, limit=limit)
+                        for r in ret:
+                            for rr in drill_ret:
+                                for k, v in rr.items():
+                                    if k in r:
+                                        r[var_name] = f'{r[var_name]} | {v}'
+                                    else:
+                                        r[var_name] = f'{r[var_name]} | {rr}'
             return ret
 
         # Object reference

--- a/credmark/types/dto_schema.py
+++ b/credmark/types/dto_schema.py
@@ -1,0 +1,146 @@
+from itertools import product
+
+
+def combine_dict(dicts):
+    dd = {}
+    for d in dicts:
+        dd |= d
+    return dd
+
+
+def cross_examples(*x, limit=10):
+    return [combine_dict(ds) for ds in product(*x)][:limit]
+
+
+def dto_schema_viz(head_node, var_name, node, n_iter, ret_type, limit=10):
+    assert ret_type in ['tree', 'example']
+    try:
+        # 1. DTO/dict
+        # 1.1 DTO with example
+        # 1.2 DTO without example
+        # 1.3 dict
+        # 2. Array
+        # 2.1 DTO
+        # 2.2 other
+        # 3. Union
+        # 4. DTO Reference
+
+        if 'type' in node:
+            if node['type'] == 'object':
+                # DTO with example
+                if ret_type == 'example' and 'examples' in node:
+                    return node["examples"]
+
+                # DTO without example
+                if ret_type == 'tree':
+                    ret = [(n_iter, var_name, node['type'])]
+                else:
+                    ret = [{}]
+
+                if 'properties' in node and len(node['properties']) > 0:
+                    props = node['properties']
+                    required = node['required'] if 'required' in node else list(props.keys())
+                    for prop_name, prop_item in props.items():
+                        if prop_name in required:
+                            if ret_type == 'tree':
+                                if len(ret) == 1:
+                                    ret = [(n_iter, var_name, node['type'])]
+                                ret.extend(dto_schema_viz(
+                                    head_node, prop_name, prop_item, n_iter + 1, ret_type, limit))
+                            elif ret_type == 'example':
+                                drill_ret = dto_schema_viz(
+                                    head_node, prop_name, prop_item, n_iter + 1, ret_type, limit)
+                                if len(ret) == 0:
+                                    ret = drill_ret
+                                else:
+                                    ret = cross_examples(ret, drill_ret, limit=limit)
+                return ret
+
+            if node['type'] == 'array':
+                # array of object
+                if '$ref' in node['items']:
+                    ref = node['items']['$ref'].split('/')
+                    definition_node = head_node[ref[1]][ref[2]]
+                    ret = dto_schema_viz(head_node, var_name,
+                                         definition_node, n_iter, ret_type, limit)
+                    if ret_type == 'tree':
+                        ret[0] = (*ret[0][:-1], f'List[{ref[2]}]')
+                        return ret
+                    return [{var_name: [x]} for x in ret]
+
+                # array of other type
+                array_type = node['items']['type'] if 'type' in node['items'] else 'Any'
+                if 'items' in node['items']:
+                    array_type = ','.join([item['type'] for item in node['items']['items']])
+                    array_type = f'({array_type})'
+                if ret_type == 'tree':
+                    return [(n_iter, var_name, f'List[{array_type}]')]
+                return [{var_name: array_type}]
+
+            # ['type'] != 'array'
+            # ordinary type
+            if ret_type == 'tree':
+                return [(n_iter, var_name, node["type"])]
+            return [{var_name: node["type"]}]
+
+        # Various Union type
+        elif 'anyOf' in node or 'allOf' in node or 'oneOf' in node:
+            ret = []
+            of_node = node.get('anyOf', node.get('allOf', node.get('oneOf')))
+            for item in of_node:
+                drill_ret = dto_schema_viz(
+                    head_node, var_name, item, n_iter, ret_type, limit)
+
+                if ret_type == 'tree':
+                    if len(ret) == 0:
+                        ret = drill_ret
+                    else:
+                        ret[0] = (ret[0][0], ret[0][1] + ' | ' + drill_ret[1])
+                elif ret_type == 'example':
+                    if len(ret) == 0:
+                        ret = drill_ret
+                    else:
+                        ret = cross_examples(ret, drill_ret, limit=limit)
+            return ret
+
+        # Object reference
+        elif '$ref' in node:
+            ref = node['$ref'].split('/')
+            definition_node = head_node[ref[1]][ref[2]]
+            return dto_schema_viz(head_node, var_name, definition_node, n_iter, ret_type, limit)
+
+        else:
+            if ret_type == 'tree':
+                return [(n_iter, var_name, 'object')]
+            return [{var_name: 'object'}]
+    except Exception as err:
+        raise ValueError(f'Unknown schema node {var_name, node, err}')
+
+
+def print_tree(tree, prefix, print_func):
+    leaf = '\u2514\u2500'  # '\N{Leafy Green}'
+    if len(tree) > 0:
+        if isinstance(tree, tuple):
+            nn, cc, tt = tree
+            if nn > 0:
+                print_func(f'{prefix}{" "*(4*nn-2)}{leaf}{cc}({tt})\n')
+            else:
+                print_func(f'{prefix}{" "*(4*nn)}{cc}({tt})\n')
+        elif isinstance(tree, list):
+            for elem in tree:
+                print_tree(elem, prefix, print_func)
+        elif isinstance(tree, dict):
+            for elem, value in tree.items():
+                print_func(f'{prefix}{elem}: {print_tree(value, prefix, print_func)}\n')
+        else:
+            raise ValueError(tree)
+    else:
+        print_func(f'{prefix}(empty)\n')
+
+
+def print_example(examples, prefix, print_func):
+    if len(examples) > 0:
+        for n, l in enumerate(examples):
+            print_func(f'{prefix}#{n+1:02d}: {l}\n')
+    else:
+        print_func(f'{prefix}{{}}\n')

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='credmark-model-framework',
-    version='0.5.9',
+    version='0.5.10',
     description='Credmark model development framework',
     long_description=readme + '\n\n' + history,
     author='Credmark',


### PR DESCRIPTION
Hi,

To use a model, developer needs finds out the input and output. With an complex DTO, it is not easy to get it right.

I added the functionality to display the schema in tree format and provide examples. The output is similar to `list --manifest` with  "input/output" been replaced with "input/output schema/example".

- call with `credmark-dev describe` to show all models.
- call with `credmark-dev describe {model_slug}` to show specific models (by partially matching the model_slug)

```
credmark-dev describe aave-token-asset-historical

2022-03-11 18:22:16,733 - credmark.model.engine.model_loader - INFO - Loading manifest from model_paths: ['models']
2022-03-11 18:22:16,937 - credmark.model.engine.model_loader - INFO - Loading dev models

Loaded models:

 - slug: aave-token-asset-historical
 - version: 1.0
 - tags: None
 - display_name: Aave V2 token liquidity
 - description: Aave V2 token liquidity at a given block number
 - developer:
 - input schema:
   Token(object)
     └─address(string)
 - input example:
   #01: {'symbol': 'USDC'}
   #02: {'symbol': 'USDC', 'decimals': 6}
   #03: {'address': '0x1F98431c8aD98523631AE4a59f267346ea31F984'}
   #04: {'address': '0x1F98431c8aD98523631AE4a59f267346ea31F984', 'abi': '(Optional) contract abi JSON string'}
 - output schema:
   BlockSeries(object)
     └─series(List[BlockSeriesRow])
         └─blockNumber(integer)
         └─blockTimestamp(integer)
         └─sampleTimestamp(integer)
         └─output(object)
 - output example:
   #01: {'series': [{'blockNumber': 'integer', 'blockTimestamp': 'integer', 'sampleTimestamp': 'integer', 'output': 'object'}]}
 - class: models.credmark.protocols.aave.aave_v2.AaveV2GetTokenAssetHistorical
```

Under the hood, it is powered by either of below two way.

1) For DTO, we can set an extra_schema under Config. The key is "examples". There is a helper function cross_examples to generate multiple examples. For example as below, Position class has two fields (amount, token). If there are 1 examples for amount and 2 examples for token, 1x2 examples will be generated from the permutation function. I added a limit so as not to blow over the roof. Output example is with limit=1 because one example for output is sufficient.

```
class Position(DTO):
    amount: float = DTOField(0.0, description='Quantity of token held')
    token: Token = DTOField(..., description='Token')

    class Config:
        schema_extra = {
            'examples': cross_examples([{'amount': '4.2', }],
                                       Token.Config.schema_extra['examples'],
                                       limit=10)
        }
```

2) For non-DTO or DTO without example setup, I wrote a simplified parser for the Pydantic schema (which follows OneAPI standard). Currently, the parser supports all existing models. Possibly, we would need to improve the parser when it fails the models with more complex types. Given this function "describe" not impacting running the model, I recommend for the merge.
