### PR TITLE
Fix describe

### DIFF
--- a/credmark/credmark_dev.py
+++ b/credmark/credmark_dev.py
@@ -283,11 +283,11 @@ def print_manifests(manifests: List[dict], describe_schemas=False):
                 else:
                     if i == 'input':
                         input_tree = dto_schema_viz(
-                            v, v.get('title', 'Object'), v, 0, 'tree', 10)
+                            v, v.get('title', 'Object'), v, 0, 'tree', only_required=False, tag='top', limit=10)
                         input_examples = dto_schema_viz(
-                            v, v.get('title', 'Object'), v, 0, 'example', 10)
+                            v, v.get('title', 'Object'), v, 0, 'example', only_required=False, tag='top', limit=10)
 
-                        print(' - input schema:')
+                        print(' - input schema (* for required field):')
                         print_tree(input_tree, '   ', sys.stdout.write)
 
                         print(' - input example:')
@@ -295,11 +295,11 @@ def print_manifests(manifests: List[dict], describe_schemas=False):
 
                     elif i == 'output':
                         output_tree = dto_schema_viz(
-                            v, v.get('title', 'Object'), v, 0, 'tree', 1)
+                            v, v.get('title', 'Object'), v, 0, 'tree', only_required=False, tag='top', limit=1)
                         output_examples = dto_schema_viz(
-                            v, v.get('title', 'Object'), v, 0, 'example', 1)
+                            v, v.get('title', 'Object'), v, 0, 'example', only_required=True, tag='top', limit=1)
 
-                        print(' - output schema:')
+                        print(' - output schema (* for required field):')
                         print_tree(output_tree, '   ', sys.stdout.write)
 
                         print(' - output example:')

--- a/credmark/types/data/position.py
+++ b/credmark/types/data/position.py
@@ -9,7 +9,8 @@ class Position(DTO):
     class Config:
         schema_extra = {
             'examples': cross_examples([{'amount': '4.2', }],
-                                       Token.Config.schema_extra['examples'],
+                                       [{'token': v}
+                                           for v in Token.Config.schema_extra['examples']],
                                        limit=10)
         }
 
@@ -17,7 +18,7 @@ class Position(DTO):
         # TODO: Figure out for non-ERC20 Tokens
         return self.token.price_usd * self.scaled_amount
 
-    @property
+    @ property
     def scaled_amount(self):
         decimals = self.token.decimals
         if decimals is None:


### PR DESCRIPTION
- Make nested objects shown correctly
- Accepts exampels from either 'example' or 'examples'
- By default, show all fields for schema/examples, except output
  examples: