### PR TITLE
Kunlun var

### DIFF
--- a/credmark/model/utils/historical_util.py
+++ b/credmark/model/utils/historical_util.py
@@ -68,7 +68,7 @@ class HistoricalUtil:
 
         if isinstance(window, list):
             parsed_window = [self.range_timestamp(*self.parse_timerangestr(w)) for w in window]
-            min_w = window[parsed_window == min(parsed_window)]
+            min_w = window[parsed_window.index(min(parsed_window))]
             (w_k, _) = self.parse_timerangestr(min_w)
             window_timestamp = sum(parsed_window)
         else:

--- a/credmark/model/utils/historical_util.py
+++ b/credmark/model/utils/historical_util.py
@@ -74,12 +74,19 @@ class HistoricalUtil:
         else:
             (w_k, w_v) = self.parse_timerangestr(window)
             window_timestamp = self.range_timestamp(w_k, w_v)
-        
+        if window_timestamp <= 0:
+            raise ModelRunError(
+                f"Negative window '{window}' specificied for historical.")
+
         if interval is not None:
             (i_k, i_v) = self.parse_timerangestr(interval)
             interval_timestamp = self.range_timestamp(i_k, i_v)
         else:
             interval_timestamp = self.range_timestamp(w_k, 1)
+
+        if i_v <= 0:
+            raise ModelRunError(
+                f"Negative interval '{window}' specified for historical.")
 
         if snap_clock is None and end_timestamp is None:
 
@@ -185,13 +192,7 @@ class HistoricalUtil:
                 f"Invalid historical time string '{time_str}': "
                 f"unit not one of {','.join(self.time_units)}")
 
-        try:
-            num = int(time_str.split(' ')[0])
-            if num <= 0:
-                num = 1
-        except Exception:
-            num = 1
-
+        num = int(time_str.split(' ')[0])
         return (key, num)
 
     def range_timestamp(self, key: str, num: int):

--- a/credmark/model/utils/historical_util.py
+++ b/credmark/model/utils/historical_util.py
@@ -70,12 +70,10 @@ class HistoricalUtil:
             parsed_window = [self.range_timestamp(*self.parse_timerangestr(w)) for w in window]
             min_w = window[parsed_window == min(parsed_window)]
             (w_k, _) = self.parse_timerangestr(min_w)
-            print('parsed_window', parsed_window)
             window_timestamp = sum(parsed_window)
         else:
             (w_k, w_v) = self.parse_timerangestr(window)
             window_timestamp = self.range_timestamp(w_k, w_v)
-        print('window_timestamp', window_timestamp)
         
         if interval is not None:
             (i_k, i_v) = self.parse_timerangestr(interval)

--- a/credmark/model/utils/historical_util.py
+++ b/credmark/model/utils/historical_util.py
@@ -76,7 +76,7 @@ class HistoricalUtil:
             window_timestamp = self.range_timestamp(w_k, w_v)
         if window_timestamp <= 0:
             raise ModelRunError(
-                f"Negative window '{window}' specificied for historical.")
+                f"Negative or zero window '{window}' specificied for historical.")
 
         if interval is not None:
             (i_k, i_v) = self.parse_timerangestr(interval)
@@ -86,7 +86,7 @@ class HistoricalUtil:
 
         if i_v <= 0:
             raise ModelRunError(
-                f"Negative interval '{window}' specified for historical.")
+                f"Negative or zero interval '{window}' specified for historical.")
 
         if snap_clock is None and end_timestamp is None:
 

--- a/credmark/model/utils/historical_util.py
+++ b/credmark/model/utils/historical_util.py
@@ -192,7 +192,12 @@ class HistoricalUtil:
                 f"Invalid historical time string '{time_str}': "
                 f"unit not one of {','.join(self.time_units)}")
 
-        num = int(time_str.split(' ')[0])
+        try:
+            num = int(time_str.split(' ')[0])
+        except Exception as err:
+            raise ModelRunError(
+                f"Invalid historical time string '{time_str}': "
+                f"unknown number format")
         return (key, num)
 
     def range_timestamp(self, key: str, num: int):


### PR DESCRIPTION
- There raises a need to pass a list of time string for window, e.g. ['1 year', '10 days''] to historical_utils. This will result in a summed up window from the list.
- Time string also accepts negative.
- Add checks for negative and unknown number format for historical_utils.