### PR TITLE
fixes for main

### DIFF
--- a/credmark/credmark_dev.py
+++ b/credmark/credmark_dev.py
@@ -97,9 +97,12 @@ def main():
     parser_run.add_argument('--provider_url_map', required=False, default=None,
                             help='JSON object of chain id to Web3 provider HTTP URL. '
                             'Overrides settings in env vars.')
+    parser_run.add_argument('--format_json', action='store_true', default=False,
+                            help='format json in print')
     add_api_url_arg(parser_run)
     parser_run.add_argument('--run_id', help=argparse.SUPPRESS, required=False, default=None)
     parser_run.add_argument('--depth', help=argparse.SUPPRESS, type=int, required=False, default=0)
+
     parser_run.add_argument('model-slug', default='(missing model-slug arg)',
                             help='Slug for the model to run.')
     parser_run.set_defaults(func=run_model, depth=0)
@@ -403,6 +406,7 @@ def run_model(args):  # pylint: disable=too-many-statements,too-many-branches,to
         api_url: Union[str, None] = args['api_url']
         run_id: Union[str, None] = args['run_id']
         depth: int = args['depth']
+        format_json: bool = args['format_json']
 
         if args['input'] != '-':
             input = json.loads(args['input'])
@@ -433,7 +437,10 @@ def run_model(args):  # pylint: disable=too-many-statements,too-many-branches,to
             else:
                 exit_code = 1
 
-        json_dump(result, sys.stdout, indent=4)
+        if format_json:
+            json_dump(result, sys.stdout, indent=4)
+        else:
+            json_dump(result, sys.stdout)
 
     except Exception as e:
         # this exception would only happen have been raised

--- a/credmark/credmark_dev.py
+++ b/credmark/credmark_dev.py
@@ -18,6 +18,7 @@ from .model.web3 import Web3Registry
 from .model.engine.model_api import ModelApi
 from .dto import (
     json_dump,
+    json_dumps,
     print_example,
     print_tree,
     dto_schema_viz,
@@ -438,7 +439,9 @@ def run_model(args):  # pylint: disable=too-many-statements,too-many-branches,to
                 exit_code = 1
 
         if format_json:
-            json_dump(result, sys.stdout, indent=4)
+            print(json_dumps(result,
+                             format_json=lambda x: x.replace('\\n', '\n').replace('\\"', '\"'),
+                             indent=4))
         else:
             json_dump(result, sys.stdout)
 

--- a/credmark/credmark_dev.py
+++ b/credmark/credmark_dev.py
@@ -439,9 +439,7 @@ def run_model(args):  # pylint: disable=too-many-statements,too-many-branches,to
                 exit_code = 1
 
         if format_json:
-            print(json_dumps(result,
-                             format_json=lambda x: x.replace('\\n', '\n').replace('\\"', '\"'),
-                             indent=4))
+            print(json_dumps(result, indent=4).replace('\\n', '\n').replace('\\"', '\"'))
         else:
             json_dump(result, sys.stdout)
 

--- a/credmark/credmark_dev.py
+++ b/credmark/credmark_dev.py
@@ -433,7 +433,7 @@ def run_model(args):  # pylint: disable=too-many-statements,too-many-branches,to
             else:
                 exit_code = 1
 
-        json_dump(result, sys.stdout)
+        json_dump(result, sys.stdout, indent=4)
 
     except Exception as e:
         # this exception would only happen have been raised

--- a/credmark/dto/encoder.py
+++ b/credmark/dto/encoder.py
@@ -17,11 +17,11 @@ class PydanticJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def json_dump(obj, handle, format_json=lambda x: x, **json_dump_args):
+def json_dump(obj, handle, **json_dump_args):
     """Dump an obj that may contain embedded DTOs to json"""
-    return format_json(json.dump(obj, handle, cls=PydanticJSONEncoder, **json_dump_args))
+    return json.dump(obj, handle, cls=PydanticJSONEncoder, **json_dump_args)
 
 
-def json_dumps(obj):
+def json_dumps(obj, format_json=lambda x: x, **json_dump_args):
     """Dump an obj that may contain embedded DTOs to json string"""
-    return json.dumps(obj, cls=PydanticJSONEncoder)
+    return format_json(json.dumps(obj, cls=PydanticJSONEncoder, **json_dump_args))

--- a/credmark/dto/encoder.py
+++ b/credmark/dto/encoder.py
@@ -17,9 +17,9 @@ class PydanticJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def json_dump(obj, fp):  # pylint: disable=invalid-name
+def json_dump(obj, fp, post_proc=lambda x:x, *a, **b):  # pylint: disable=invalid-name
     """Dump an obj that may contain embedded DTOs to json"""
-    return json.dump(obj, fp, cls=PydanticJSONEncoder)
+    return post_proc(json.dump(obj, fp, cls=PydanticJSONEncoder, *a, **b))
 
 
 def json_dumps(obj):

--- a/credmark/dto/encoder.py
+++ b/credmark/dto/encoder.py
@@ -17,9 +17,9 @@ class PydanticJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def json_dump(obj, fp, post_proc=lambda x:x, *a, **b):  # pylint: disable=invalid-name
+def json_dump(obj, fp, post_proc=lambda x: x, **b):  # pylint: disable=invalid-name
     """Dump an obj that may contain embedded DTOs to json"""
-    return post_proc(json.dump(obj, fp, cls=PydanticJSONEncoder, *a, **b))
+    return post_proc(json.dump(obj, fp, cls=PydanticJSONEncoder, **b))
 
 
 def json_dumps(obj):

--- a/credmark/dto/encoder.py
+++ b/credmark/dto/encoder.py
@@ -17,9 +17,9 @@ class PydanticJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def json_dump(obj, fp, post_proc=lambda x: x, **b):  # pylint: disable=invalid-name
+def json_dump(obj, fp, format_json=lambda x: x, **json_dump_args):  # pylint: disable=invalid-name
     """Dump an obj that may contain embedded DTOs to json"""
-    return post_proc(json.dump(obj, fp, cls=PydanticJSONEncoder, **b))
+    return format_json(json.dump(obj, fp, cls=PydanticJSONEncoder, **json_dump_args))
 
 
 def json_dumps(obj):

--- a/credmark/dto/encoder.py
+++ b/credmark/dto/encoder.py
@@ -22,6 +22,6 @@ def json_dump(obj, handle, **json_dump_args):
     return json.dump(obj, handle, cls=PydanticJSONEncoder, **json_dump_args)
 
 
-def json_dumps(obj, format_json=lambda x: x, **json_dump_args):
+def json_dumps(obj, **json_dump_args):
     """Dump an obj that may contain embedded DTOs to json string"""
-    return format_json(json.dumps(obj, cls=PydanticJSONEncoder, **json_dump_args))
+    return json.dumps(obj, cls=PydanticJSONEncoder, **json_dump_args)

--- a/credmark/dto/encoder.py
+++ b/credmark/dto/encoder.py
@@ -17,9 +17,9 @@ class PydanticJSONEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def json_dump(obj, fp, format_json=lambda x: x, **json_dump_args):  # pylint: disable=invalid-name
+def json_dump(obj, handle, format_json=lambda x: x, **json_dump_args):
     """Dump an obj that may contain embedded DTOs to json"""
-    return format_json(json.dump(obj, fp, cls=PydanticJSONEncoder, **json_dump_args))
+    return format_json(json.dump(obj, handle, cls=PydanticJSONEncoder, **json_dump_args))
 
 
 def json_dumps(obj):

--- a/credmark/model/describe.py
+++ b/credmark/model/describe.py
@@ -127,16 +127,16 @@ def validate_model_slug(slug: str, prefix: Union[str, None] = None):
     if model_slug_re.match(slug) is None or len(slug) > MAX_SLUG_LENGTH:
         quoted_prefix = f'"{prefix}"' if prefix else ''
         raise InvalidModelSlug(
-            f'Invalid model slug "{slug}". ' +
-            (f'Following the prefix {quoted_prefix}' if prefix else 'Following a prefix and dot') +
-            ', slugs must start and end with a letter or number and may contain hyphens.')
+            f'Invalid model slug "{slug}". '
+            f'{"Following the prefix " + quoted_prefix if prefix else "Following a prefix and dot"}, '
+            'slugs must start and end with a letter or number and may contain hyphens.')
     if len(slug) > MAX_SLUG_LENGTH:
         raise InvalidModelSlug(
             f'Invalid model slug "{slug}". '
             'Slugs must be not more than {MAX_SLUG_LENGTH} characters.')
 
 
-def describe(slug: str,   # pylint: disable=too-many-arguments
+def describe(slug: str,   # pylint: disable=locally-disabled, invalid-name
              version: str,
              tags: Union[list[str], None] = None,
              display_name: Union[str, None] = None,
@@ -161,10 +161,6 @@ def describe(slug: str,   # pylint: disable=too-many-arguments
         else:
             validate_model_slug(slug)
 
-        model_desc = description
-        if model_desc is None:
-            model_desc = cls.__doc__.strip() if cls.__doc__ is not None else None
-
         attr_value = {
             'credmarkModelManifest': 'v1',
             'model': {
@@ -172,7 +168,7 @@ def describe(slug: str,   # pylint: disable=too-many-arguments
                 'version': version,
                 'tags': tags,
                 'display_name': display_name,
-                'description': model_desc,
+                'description': description,
                 'developer': developer if developer is not None else '',
                 'input': input.schema() if input is not None and issubclass(input, DTO)
                 else DICT_SCHEMA,

--- a/credmark/model/describe.py
+++ b/credmark/model/describe.py
@@ -161,6 +161,10 @@ def describe(slug: str,  # pylint: disable=too-many-arguments
         else:
             validate_model_slug(slug)
 
+        model_desc = description
+        if model_desc is None:
+            model_desc = cls.__doc__.strip() if cls.__doc__ is not None else None
+
         attr_value = {
             'credmarkModelManifest': 'v1',
             'model': {
@@ -168,7 +172,7 @@ def describe(slug: str,  # pylint: disable=too-many-arguments
                 'version': version,
                 'tags': tags,
                 'display_name': display_name,
-                'description': description,
+                'description': model_desc,
                 'developer': developer if developer is not None else '',
                 'input': input.schema() if input is not None and issubclass(input, DTO)
                 else DICT_SCHEMA,

--- a/credmark/model/describe.py
+++ b/credmark/model/describe.py
@@ -128,15 +128,15 @@ def validate_model_slug(slug: str, prefix: Union[str, None] = None):
         quoted_prefix = f'"{prefix}"' if prefix else ''
         raise InvalidModelSlug(
             f'Invalid model slug "{slug}". '
-            f'{"Following the prefix " + quoted_prefix if prefix else "Following a prefix and dot"}, '
-            'slugs must start and end with a letter or number and may contain hyphens.')
+            "Following the prefix " + quoted_prefix if prefix else "Following a prefix and dot"
+            ', slugs must start and end with a letter or number and may contain hyphens.')
     if len(slug) > MAX_SLUG_LENGTH:
         raise InvalidModelSlug(
             f'Invalid model slug "{slug}". '
             'Slugs must be not more than {MAX_SLUG_LENGTH} characters.')
 
 
-def describe(slug: str,   # pylint: disable=locally-disabled, invalid-name
+def describe(slug: str,  # pylint: disable=too-many-arguments
              version: str,
              tags: Union[list[str], None] = None,
              display_name: Union[str, None] = None,

--- a/credmark/model/dev_models/series_models.py
+++ b/credmark/model/dev_models/series_models.py
@@ -46,14 +46,15 @@ def run_model_for_block_range(context: ModelContext,
     return block_series
 
 
-@credmark.model.describe(slug='series.time-start-end-interval',
-                         version='0.0',
-                         display_name='Series Time Interval',
-                         description='Run a model over a series of blocks specifying '
-                         'a time start, end, and interval',
-                         developer='Credmark',
-                         input=SeriesModelStartEndIntervalInput,
-                         output=BlockSeries[dict])
+@credmark.model.describe(
+    slug='series.time-start-end-interval',
+    version='0.0',
+    display_name='Series Time Interval',
+    description='Run a model over a series of blocks specifying '
+    'a time start, end, and interval',
+    developer='Credmark',
+    input=SeriesModelStartEndIntervalInput,
+    output=BlockSeries[dict])
 class SeriesTimeStartEndInterval(credmark.model.Model):
 
     def run(self, input: SeriesModelStartEndIntervalInput) -> BlockSeries[dict]:

--- a/credmark/model/engine/context.py
+++ b/credmark/model/engine/context.py
@@ -333,8 +333,12 @@ class EngineModelContext(ModelContext):
                     err.transform_data_detail(None)
                 else:
                     if self.dev_mode:
-                        self.logger.exception(f'Exception running model {slug}: {err}')
-                    err = ModelRunError(f'Exception running model {slug}: {err}')
+                        self.logger.exception(
+                            f'Exception running model {slug}: {err} on '
+                            f'block {context.block_number}/{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
+                    err = ModelRunError(
+                        f'Exception running model {slug}: {err} on '
+                        f'{context.block_number}/{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
                     trace = traceback.format_exc(limit=30)
                 # We add the model just run (or validated input for) to stack
                 err.data.stack.insert(0,

--- a/credmark/model/engine/context.py
+++ b/credmark/model/engine/context.py
@@ -335,10 +335,12 @@ class EngineModelContext(ModelContext):
                     if self.dev_mode:
                         self.logger.exception(
                             f'Exception running model {slug}: {err} on '
-                            f'block {context.block_number}/{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
+                            f'block {context.block_number}/'
+                            f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
                     err = ModelRunError(
                         f'Exception running model {slug}: {err} on '
-                        f'{context.block_number}/{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
+                        f'{context.block_number}/'
+                        f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
                     trace = traceback.format_exc(limit=30)
                 # We add the model just run (or validated input for) to stack
                 err.data.stack.insert(0,

--- a/credmark/model/engine/context.py
+++ b/credmark/model/engine/context.py
@@ -334,11 +334,11 @@ class EngineModelContext(ModelContext):
                 else:
                     if self.dev_mode:
                         self.logger.exception(
-                            f'Exception running model {slug}: {err} on '
+                            f'Exception running model {slug}({input}) with {err} on '
                             f'block {context.block_number}/'
                             f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
                     err = ModelRunError(
-                        f'Exception running model {slug}: {err} on '
+                        f'Exception running model {slug}({input}) with {err} on '
                         f'block {context.block_number}/'
                         f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
                     trace = traceback.format_exc(limit=30)

--- a/credmark/model/engine/context.py
+++ b/credmark/model/engine/context.py
@@ -339,7 +339,7 @@ class EngineModelContext(ModelContext):
                             f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
                     err = ModelRunError(
                         f'Exception running model {slug}: {err} on '
-                        f'{context.block_number}/'
+                        f'block {context.block_number}/'
                         f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
                     trace = traceback.format_exc(limit=30)
                 # We add the model just run (or validated input for) to stack

--- a/credmark/model/engine/context.py
+++ b/credmark/model/engine/context.py
@@ -334,13 +334,15 @@ class EngineModelContext(ModelContext):
                 else:
                     if self.dev_mode:
                         self.logger.exception(
-                            f'Exception running model {slug}({input}) with {err} on '
+                            f'Exception running model {slug}({input}) on '
                             f'block {context.block_number}/'
-                            f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
+                            f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S} '
+                            f'with {err}')
                     err = ModelRunError(
-                        f'Exception running model {slug}({input}) with {err} on '
+                        f'Exception running model {slug}({input}) on '
                         f'block {context.block_number}/'
-                        f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S}')
+                        f'{context.block_number.timestamp_datetime:%Y-%m-%d %H:%M%S} '
+                        f'with {err}')
                     trace = traceback.format_exc(limit=30)
                 # We add the model just run (or validated input for) to stack
                 err.data.stack.insert(0,

--- a/credmark/model/utils/contract_util.py
+++ b/credmark/model/utils/contract_util.py
@@ -1,4 +1,7 @@
-from credmark.types import Contract, Address
+from credmark.types import (
+    Contract,
+    Address
+)
 import credmark.model
 
 from typing import (

--- a/credmark/types/__init__.py
+++ b/credmark/types/__init__.py
@@ -20,6 +20,6 @@ from .models.rpc import (
     RpcBlockRangeOutput
 )
 
-from .data.portfolio import Portfolio
+from .data.portfolio import (Portfolio, PriceList)
 from .data.position import Position, NativePosition, TokenPosition
 from .data.price import Price, TokenPairPrice

--- a/credmark/types/__init__.py
+++ b/credmark/types/__init__.py
@@ -20,6 +20,6 @@ from .models.rpc import (
     RpcBlockRangeOutput
 )
 
-from .data.portfolio import (Portfolio, PriceList)
+from .data.portfolio import Portfolio
 from .data.position import Position, NativePosition, TokenPosition
-from .data.price import Price, TokenPairPrice
+from .data.price import Price, TokenPairPrice, PriceList

--- a/credmark/types/data/address.py
+++ b/credmark/types/data/address.py
@@ -2,6 +2,7 @@ import re
 from typing import (
     Dict,
     Any,
+    Union,
 )
 
 from web3 import Web3
@@ -67,7 +68,7 @@ class Address(str):
             raise TypeError('Address instance must be created with a string or int')
         return str.__new__(cls, addr.lower())
 
-    def __init__(self, _addr: str):
+    def __init__(self, _addr: Union[int, str]):
         super().__init__()
         self._checksum = validate_address(self)
 

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -17,7 +17,7 @@ from credmark.dto import PrivateAttr, IterableListGenericDTO, DTOField, DTO
 from credmark.types.data.data_content.transparent_proxy_data import UPGRADEABLE_CONTRACT_ABI
 
 
-class Singleton(object):
+class Singleton:
     def __new__(cls, *args, **kw):
         if not hasattr(cls, '_instance'):
             orig = super(Singleton, cls)

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -162,7 +162,7 @@ class Contract(Account):
             return self._instance
 
     @ property
-    def proxy_for(self):
+    def proxy_for(self):  # pylint:disable = too-many-branches
         if not self._loaded:
             self._load()
 
@@ -302,7 +302,7 @@ class Contract(Account):
         return self._meta.abi
 
     @ property
-    def is_transparent_proxy(self):
+    def is_transparent_proxy(self):  # pylint:disable= too-many-return-statements
         """
         Determines proxy type by contract_name / abi
         """
@@ -312,7 +312,8 @@ class Contract(Account):
             # Example: 0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9 Aave Token (AAVE)
             return True
         if self._meta.contract_name == "InitializableImmutableAdminUpgradeabilityProxy":
-            # Example: 0x6C5024Cd4F8A59110119C56f8933403A539555EB, Aave interest bearing SUSD (aSUSD)
+            # Example: 0x6C5024Cd4F8A59110119C56f8933403A539555EB,
+            # Aave interest bearing SUSD (aSUSD)
             return True
         if self._meta.contract_name == "AdminUpgradeabilityProxy":
             # Example: 0xD46bA6D942050d489DBd938a2C909A5d5039A161, Ampleforth (AMPL)

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -101,7 +101,7 @@ class Contract(Account):
     def instance(self):
         if self._instance is None:
             context = credmark.model.ModelContext.current_context()
-            if self.abi is not None:  # call .abi() to ._load()
+            if self.abi is not None:  # calling .abi() would call ._load()
                 self._instance = context.web3.eth.contract(
                     address=context.web3.toChecksumAddress(self.address),
                     abi=self.abi

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -14,7 +14,9 @@ import credmark.model
 from credmark.model.errors import ModelDataError
 from credmark.types.data.account import Account, Address
 from credmark.dto import PrivateAttr, IterableListGenericDTO, DTOField, DTO
-from credmark.types.data.data_content.transparent_proxy_data import UPGRADEABLE_CONTRACT_ABI
+
+from .data_content.transparent_proxy_data import UPGRADEABLE_CONTRACT_ABI
+from .data_content.fungible_token_data import ERC20_GENERIC_ABI
 
 
 class Singleton:
@@ -145,8 +147,14 @@ class Contract(Account):
                     proxy_address = self.constructor_args[-40:]
 
                 if proxy_address[-40:] != default_proxy_address:
-                    self._proxy_for = Contract(address=Address(
-                        '0x' + proxy_address[-40:]))
+                    # TODO: some proxy's abi is still missing in DB.
+                    # e.g. 0x019ff0619e1d8cd2d550940ec743fde6d268afe2
+                    if self.__class__.__name__ == 'Token':
+                        self._proxy_for = Contract(address=Address(
+                            '0x' + proxy_address[-40:]), abi=ERC20_GENERIC_ABI)
+                    else:
+                        self._proxy_for = Contract(address=Address(
+                            '0x' + proxy_address[-40:]))
                     return self._proxy_for
 
             # TODO: Get this from the database, Not the RPC

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -96,7 +96,7 @@ class Contract(Account):
                 raise ModelDataError(f'abi not available for address {self.address}')
         self._loaded = True
 
-    @ property
+    @property
     def instance(self):
         if self._instance is None:
             context = credmark.model.ModelContext.current_context()
@@ -111,6 +111,7 @@ class Contract(Account):
     def proxy_for(self):
         if not self._loaded:
             self._load()
+
         if self._proxy_for is None and self.is_transparent_proxy and self.instance is not None:
             context = credmark.model.ModelContext.current_context()
 
@@ -164,9 +165,10 @@ class Contract(Account):
                 address=context.web3.toChecksumAddress(self.address),
                 abi=self.proxy_for.abi
             ).functions
-        return self.instance.functions
+        if self.instance is not None:
+            return self.instance.functions
 
-    @ property
+    @property
     def events(self):
         if self.proxy_for is not None:
             context = credmark.model.ModelContext.current_context()
@@ -174,7 +176,8 @@ class Contract(Account):
                 address=context.web3.toChecksumAddress(self.address),
                 abi=self.proxy_for.abi
             ).events
-        return self.instance.events
+        if self.instance is not None:
+            return self.instance.events
 
     @ property
     def info(self):
@@ -207,7 +210,7 @@ class Contract(Account):
             self._load()
         return self._meta.abi
 
-    @ property
+    @property
     def is_transparent_proxy(self):
         # TODO : Find a more definitive token proxy identification mechanism
         if self._meta.contract_name == "InitializableAdminUpgradeabilityProxy":

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -100,19 +100,18 @@ class Contract(Account):
     def instance(self):
         if self._instance is None:
             context = credmark.model.ModelContext.current_context()
-            if self.abi is None:
-                self._load()
-            self._instance = context.web3.eth.contract(
-                address=context.web3.toChecksumAddress(self.address),
-                abi=self.abi
-            )
+            if self.abi is not None:
+                self._instance = context.web3.eth.contract(
+                    address=context.web3.toChecksumAddress(self.address),
+                    abi=self.abi
+                )
         return self._instance
 
     @ property
     def proxy_for(self):
         if not self._loaded:
             self._load()
-        if self._proxy_for is None and self.is_transparent_proxy:
+        if self._proxy_for is None and self.is_transparent_proxy and self.instance is not None:
             context = credmark.model.ModelContext.current_context()
 
             # TODO: Get this from the database, Not the RPC

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -138,7 +138,7 @@ class Contract(Account):
                         abi_codec=context.web3.codec,
                         event_abi=event_abi,
                         address=self.address.checksum,
-                        fromBlock=0,
+                        fromBlock=context.block_number - 10,
                         toBlock=context.block_number
                     )
                     events = context.web3.eth.get_logs(event_filter_params)
@@ -167,8 +167,10 @@ class Contract(Account):
             ).functions
         if self.instance is not None:
             return self.instance.functions
+        else:
+            raise ModelDataError('Unable to load the instance of the contract')
 
-    @property
+    @ property
     def events(self):
         if self.proxy_for is not None:
             context = credmark.model.ModelContext.current_context()
@@ -178,6 +180,8 @@ class Contract(Account):
             ).events
         if self.instance is not None:
             return self.instance.events
+        else:
+            raise ModelDataError('Unable to load the instance of the contract')
 
     @ property
     def info(self):
@@ -210,7 +214,7 @@ class Contract(Account):
             self._load()
         return self._meta.abi
 
-    @property
+    @ property
     def is_transparent_proxy(self):
         # TODO : Find a more definitive token proxy identification mechanism
         if self._meta.contract_name == "InitializableAdminUpgradeabilityProxy":

--- a/credmark/types/data/contract.py
+++ b/credmark/types/data/contract.py
@@ -94,6 +94,7 @@ class Contract(Account):
         else:
             if self._meta.abi is None:
                 raise ModelDataError(f'abi not available for address {self.address}')
+
         self._loaded = True
 
     @property
@@ -157,7 +158,6 @@ class Contract(Account):
                             '0x' + self.constructor_args[-40:]))
                     else:
                         raise ModelDataError('Unable to retrieve abi for proxy')
-
         return self._proxy_for
 
     @ property

--- a/credmark/types/data/portfolio.py
+++ b/credmark/types/data/portfolio.py
@@ -4,11 +4,9 @@ from credmark.dto import (
     DTOField,
     PrivateAttr,
     IterableListGenericDTO,
-    cross_examples
 )
-from .account import Account
+
 from .address import Address
-from .price import Price
 
 from .position import Position
 
@@ -24,11 +22,11 @@ class Portfolio(IterableListGenericDTO[Position]):
 
 
 class PriceList(DTO):
-    price: Price
-    token: Address
+    prices: List[float]
+    tokenAddress: Address
 
     class Config:
         schema_extra: dict = {
-            'examples': cross_examples(Price.Config.schema_extra['examples'],
-                                       Account.Config.schema_extra['examples'])
+            'examples': [{'prices': [4.2, 2.3],
+                          'tokenAddress': '0x6B175474E89094C44Da98b954EedeAC495271d0F'}]
         }

--- a/credmark/types/data/portfolio.py
+++ b/credmark/types/data/portfolio.py
@@ -1,12 +1,9 @@
 from typing import List
 from credmark.dto import (
-    DTO,
     DTOField,
     PrivateAttr,
     IterableListGenericDTO,
 )
-
-from .address import Address
 
 from .position import Position
 
@@ -18,15 +15,4 @@ class Portfolio(IterableListGenericDTO[Position]):
     class Config:
         schema_extra: dict = {
             'examples': [{'positions': [exp]} for exp in Position.Config.schema_extra['examples']]
-        }
-
-
-class PriceList(DTO):
-    prices: List[float]
-    tokenAddress: Address
-
-    class Config:
-        schema_extra: dict = {
-            'examples': [{'prices': [4.2, 2.3],
-                          'tokenAddress': '0x6B175474E89094C44Da98b954EedeAC495271d0F'}]
         }

--- a/credmark/types/data/price.py
+++ b/credmark/types/data/price.py
@@ -1,8 +1,15 @@
 from typing import (
-    Union
+    Union,
+    List,
 )
-from credmark.dto import DTO, DTOField
+from credmark.dto import (
+    DTO,
+    DTOField,
+    IterableListGenericDTO,
+    PrivateAttr,
+)
 from .token import Token
+from .address import Address
 
 
 class Price(DTO):
@@ -25,4 +32,17 @@ class TokenPairPrice(Price):
     class Config:
         schema_extra: dict = {
             'examples': [{'token': Token.Config.schema_extra['examples']}]
+        }
+
+
+class PriceList(IterableListGenericDTO[float]):
+    prices: List[float] = DTOField(default=[], description='List of prices')
+    tokenAddress: Address
+    src: Union[str, None] = DTOField(None, description='Source')
+    _iterator: str = PrivateAttr('prices')
+
+    class Config:
+        schema_extra: dict = {
+            'examples': [{'prices': [4.2, 2.3],
+                          'tokenAddress': '0x6B175474E89094C44Da98b954EedeAC495271d0F'}]
         }

--- a/credmark/types/data/price.py
+++ b/credmark/types/data/price.py
@@ -7,10 +7,12 @@ from .token import Token
 
 class Price(DTO):
     price: Union[float, None] = DTOField(None, description='Value of one Token')
+    src: Union[str, None] = DTOField(None, description='Source')
 
     class Config:
         schema_extra: dict = {
-            'examples': [{'price': 4.2}]
+            'examples': [{'price': 4.2},
+                         {'price': 4.2, 'src': 'uniswap-v3'}]
         }
 
 

--- a/credmark/types/data/token.py
+++ b/credmark/types/data/token.py
@@ -66,11 +66,14 @@ class Token(Contract):
 
     def __init__(self, **data):
 
-        if 'address' not in data and 'symbol' in data:
+        if 'address' in data or 'symbol' in data:
             context = credmark.model.ModelContext.current_context()
 
             token_data = get_token_from_configuration(
-                chain_id=str(context.chain_id), symbol=data['symbol'])
+                chain_id=str(context.chain_id),
+                symbol=data.get('symbol', None),
+                address=data.get('address', None))
+
             if token_data is not None:
                 data['address'] = token_data['address']
                 if 'meta' not in data:

--- a/credmark/types/data/token.py
+++ b/credmark/types/data/token.py
@@ -23,7 +23,7 @@ def get_token_from_configuration(
     token_datas = [
         t for t in FUNGIBLE_TOKEN_DATA.get(chain_id, [])
         if (t.get('is_native_token', False) == is_native_token and
-            (t.get('address', None) == address or
+            (('address' in t and Address(t['address']) == address) or
              t.get('symbol', None) == symbol) or
             (t.get('wraps', None) == wraps and wraps is not None))
     ]
@@ -65,7 +65,6 @@ class Token(Contract):
         }
 
     def __init__(self, **data):
-
         if 'address' in data or 'symbol' in data:
             context = credmark.model.ModelContext.current_context()
 
@@ -78,6 +77,8 @@ class Token(Contract):
                 data['address'] = token_data['address']
                 if 'meta' not in data:
                     data['meta'] = {}
+                elif isinstance(data['meta'], self.TokenMetadata):
+                    data['meta'] = data['meta'].dict()
                 data['meta']['symbol'] = token_data['symbol']
                 data['meta']['name'] = token_data['name']
                 data['meta']['decimals'] = token_data['decimals']

--- a/credmark/types/data/token.py
+++ b/credmark/types/data/token.py
@@ -110,7 +110,6 @@ class Token(Contract):
             except (BadFunctionCallOutput, ABIFunctionNotFound):
                 raise ModelDataError(
                     f'No symbol function on token {self.address}, non ERC20 Compliant')
-
         return self._meta.symbol
 
     @property

--- a/credmark/types/data/token.py
+++ b/credmark/types/data/token.py
@@ -110,6 +110,8 @@ class Token(Contract):
             except (BadFunctionCallOutput, ABIFunctionNotFound):
                 raise ModelDataError(
                     f'No symbol function on token {self.address}, non ERC20 Compliant')
+            if self._meta.symbol is None:
+                raise ModelDataError("Token.symbol is None")
         return self._meta.symbol
 
     @property
@@ -134,6 +136,8 @@ class Token(Contract):
             except (BadFunctionCallOutput, ABIFunctionNotFound):
                 raise ModelDataError(
                     f'No name function on token {self.address}, non ERC20 Compliant')
+            if self._meta.name is None:
+                raise ModelDataError("Token.name is None")
         return self._meta.name
 
     @property
@@ -145,6 +149,8 @@ class Token(Contract):
             except (BadFunctionCallOutput, ABIFunctionNotFound):
                 raise ModelDataError(
                     f'No totalSupply function on token {self.address}, non ERC20 Compliant')
+            if self._meta.total_supply is None:
+                raise ModelDataError("Token.total_supply is None")
         return self._meta.total_supply
 
     def scaled(self, value):

--- a/credmark/types/data/token.py
+++ b/credmark/types/data/token.py
@@ -87,9 +87,12 @@ class Token(Contract):
     def _load(self):
         if self._loaded:
             return
+
         if self._meta.abi is None:
             self._meta.abi = ERC20_GENERIC_ABI
+
         super()._load()
+
         if self._meta.symbol is None:
             try:
                 self._meta.symbol = self.functions.symbol().call()

--- a/credmark/types/data/token.py
+++ b/credmark/types/data/token.py
@@ -93,31 +93,6 @@ class Token(Contract):
 
         super()._load()
 
-        if self._meta.symbol is None:
-            try:
-                self._meta.symbol = self.functions.symbol().call()
-            except (BadFunctionCallOutput, ABIFunctionNotFound):
-                raise ModelDataError(
-                    f'No symbol function on token {self.address}, non ERC20 Compliant')
-        if self._meta.name is None:
-            try:
-                self._meta.name = self.functions.name().call()
-            except (BadFunctionCallOutput, ABIFunctionNotFound):
-                raise ModelDataError(
-                    f'No name function on token {self.address}, non ERC20 Compliant')
-        if self._meta.decimals is None:
-            try:
-                self._meta.decimals = self.functions.decimals().call()
-            except (BadFunctionCallOutput, ABIFunctionNotFound):
-                raise ModelDataError(
-                    f'No decimals function on token {self.address}, non ERC20 Compliant')
-        if self._meta.total_supply is None:
-            try:
-                self._meta.total_supply = self.functions.totalSupply().call()
-            except (BadFunctionCallOutput, ABIFunctionNotFound):
-                raise ModelDataError(
-                    f'No totalSupply function on token {self.address}, non ERC20 Compliant')
-
     @property
     def info(self):
         if isinstance(self, TokenInfo):
@@ -129,23 +104,48 @@ class Token(Contract):
     @property
     def symbol(self):
         self._load()
+        if self._meta.symbol is None:
+            try:
+                self._meta.symbol = self.functions.symbol().call()
+            except (BadFunctionCallOutput, ABIFunctionNotFound):
+                raise ModelDataError(
+                    f'No symbol function on token {self.address}, non ERC20 Compliant')
+
         return self._meta.symbol
 
     @property
     def decimals(self) -> int:
         self._load()
-        if self._meta.decimals is not None:
-            return self._meta.decimals
-        raise ModelDataError("Token.decimals is None")
+        if self._meta.decimals is None:
+            try:
+                self._meta.decimals = self.functions.decimals().call()
+            except (BadFunctionCallOutput, ABIFunctionNotFound):
+                raise ModelDataError(
+                    f'No decimals function on token {self.address}, non ERC20 Compliant')
+            if self._meta.decimals is None:
+                raise ModelDataError("Token.decimals is None")
+        return self._meta.decimals
 
     @property
     def name(self):
         self._load()
+        if self._meta.name is None:
+            try:
+                self._meta.name = self.functions.name().call()
+            except (BadFunctionCallOutput, ABIFunctionNotFound):
+                raise ModelDataError(
+                    f'No name function on token {self.address}, non ERC20 Compliant')
         return self._meta.name
 
     @property
     def total_supply(self):
         self._load()
+        if self._meta.total_supply is None:
+            try:
+                self._meta.total_supply = self.functions.totalSupply().call()
+            except (BadFunctionCallOutput, ABIFunctionNotFound):
+                raise ModelDataError(
+                    f'No totalSupply function on token {self.address}, non ERC20 Compliant')
         return self._meta.total_supply
 
     def scaled(self, value):

--- a/tests/test_address.py
+++ b/tests/test_address.py
@@ -1,7 +1,6 @@
 import unittest
 import logging
 
-import credmark.model
 from credmark.dto import DTO, DTOField
 from credmark.types import Address
 import functools
@@ -33,6 +32,10 @@ class TestStringMethods(unittest.TestCase):
         )
 
         addr1 = '0xd905e2eaebe188fc92179b6350807d8bd91db0d8'
+
+        self.assertEqual(Address(0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8),
+                         Address(0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8))
+
         self.assertEqual(Address(0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8),  # type: ignore
                          addr1.lower())
         self.assertEqual(Address('0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8'), addr1.lower())


### PR DESCRIPTION
A few small fixes:
- When dump json with model run, use indent=4 to print multi-line results for reading
- When throw out error, add block_number information. Good for debugging Contract
- Add a local in-memory cache for contract.meta. When creating the same token for different swap protocols during querying token.prices, it's slow and hitting DB each time if without cache,
- Optimize Token._load(), move each property (i.e. symbol, decimals, etc) retrieval code to each property. It may take up to 1.x sec from usual a few micro-seconds. When doing historical query, this could slow things down.
- Add alternative web3 event filtering for some node server.
- Fix for loading instance()/functions, they only return non-None. 
- To allow fungible token query with address, to solve the current token loading issues, mostly for upgradeable tokens.
- Various fixes for linting and pylance pdate Address class 
- Passed tests against all current models.