### PR TITLE
Convert token's name / symbol when bytes returned

### DIFF
--- a/credmark/cmf/types/token.py
+++ b/credmark/cmf/types/token.py
@@ -1,5 +1,3 @@
-
-from numpy import isin
 import credmark.cmf.model
 from credmark.cmf.model.errors import ModelDataError, ModelRunError
 


### PR DESCRIPTION
Some token returns bytes instead of string for name/symbol when the ABI is `[{"name":"","type":"bytes32"}]`

```
In [1]: mkr = Token(address='0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2')
In [2]: mkr.symbol
Out[2]: b'MKR\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
In [3]: mkr.name
Out[3]: b'Maker\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
```

Added conversion code when the returned value from web3 is in bytes. This helps caching. Gateway API cannot cache the result containing the bytes data when it expected string.

```
In [1]: mkr = Token(address='0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2')

In [2]: mkr.symbol
Out[2]: 'MKR'

In [3]: mkr.name
Out[3]: 'Maker'
```

