### PR TITLE
Fix type hints for token and models.__call__()

### DIFF
--- a/credmark/cmf/model/context.py
+++ b/credmark/cmf/model/context.py
@@ -46,7 +46,7 @@ class RunModelMethod:
                 self.__doc__ = f'Run a model.\n\nAvailable models: {", ".join(slugs)}'
 
     # run a model. args can be a positional DTO or dict or kwargs
-    def __call__(self, input: Union[DTO, dict, None] = None, return_type=None, **kwargs) -> dict:
+    def __call__(self, input: Union[DTO, dict, None] = None, return_type=None, **kwargs):
         if isinstance(input, DTO):
             input = input.dict()
         elif input is None:

--- a/credmark/cmf/model/context.py
+++ b/credmark/cmf/model/context.py
@@ -46,10 +46,24 @@ class RunModelMethod:
                 self.__doc__ = f'Run a model.\n\nAvailable models: {", ".join(slugs)}'
 
     # run a model. args can be a positional DTO or dict or kwargs
+    @overload
     def __call__(self,
                  input: Union[DTO, dict, None] = None,
-                 return_type: Union[DTO, dict, None] = None,
-                 **kwargs):
+                 return_type: Union[dict, None] = None,
+                 **kwargs) -> dict:
+        ...
+
+    @overload
+    def __call__(self,
+                 input: Union[DTO, dict, None] = None,
+                 return_type: Type[DTO] = EmptyInput,
+                 **kwargs) -> DTO:
+        ...
+
+    def __call__(self,
+                 input: Union[DTO, dict, None] = None,
+                 return_type: Union[dict, Type[DTO], None] = None,
+                 **kwargs) -> Union[dict, DTO]:
         if isinstance(input, DTO):
             input = input.dict()
         elif input is None:
@@ -61,6 +75,7 @@ class RunModelMethod:
             return_type=return_type)
 
     # Handle method calls where the prefix is the dot prefix of a model name
+
     def __getattr__(self, __name: str):
         if self.interactive_docs:
             model_manifests: dict = self.__context._model_manifests(True)

--- a/credmark/cmf/model/context.py
+++ b/credmark/cmf/model/context.py
@@ -46,7 +46,10 @@ class RunModelMethod:
                 self.__doc__ = f'Run a model.\n\nAvailable models: {", ".join(slugs)}'
 
     # run a model. args can be a positional DTO or dict or kwargs
-    def __call__(self, input: Union[DTO, dict, None] = None, return_type=None, **kwargs):
+    def __call__(self,
+                 input: Union[DTO, dict, None] = None,
+                 return_type: Union[DTO, dict, None] = None,
+                 **kwargs):
         if isinstance(input, DTO):
             input = input.dict()
         elif input is None:

--- a/credmark/cmf/types/token.py
+++ b/credmark/cmf/types/token.py
@@ -122,9 +122,7 @@ class Token(Contract):
             symbol_tmp = self.try_erc20_property('symbol')
             if isinstance(symbol_tmp, bytes):
                 symbol_tmp = symbol_tmp.decode('utf-8', errors='strict').replace('\x00', '')
-            elif isinstance(symbol_tmp, str):
-                pass
-            else:
+            elif not isinstance(symbol_tmp, str):
                 raise ModelDataError(f'Unknown value for symbol {symbol_tmp}')
             self._meta.symbol = symbol_tmp
         return self._meta.symbol
@@ -143,9 +141,7 @@ class Token(Contract):
             name_tmp = self.try_erc20_property('name')
             if isinstance(name_tmp, bytes):
                 name_tmp = name_tmp.decode('utf-8', errors='strict').replace('\x00', '')
-            elif isinstance(name_tmp, str):
-                pass
-            else:
+            elif not isinstance(name_tmp, str):
                 raise ModelDataError(f'Unknown value for name {name_tmp}')
             self._meta.name = name_tmp
         return self._meta.name

--- a/credmark/cmf/types/token.py
+++ b/credmark/cmf/types/token.py
@@ -132,23 +132,27 @@ class Token(Contract):
         return self._meta.decimals
 
     @property
-    def name(self):
+    def name(self) -> str:
         self._load()
         if self._meta.name is None:
             name_tmp = self.try_erc20_property('name')
             if isinstance(name_tmp, bytes):
                 name_tmp = name_tmp.decode('utf-8', errors='strict').replace('\x00', '')
+            elif isinstance(name_tmp, str):
+                pass
+            else:
+                raise ModelDataError(f'Unknown value for name {name_tmp}')
             self._meta.name = name_tmp
         return self._meta.name
 
     @property
-    def total_supply(self):
+    def total_supply(self) -> int:
         self._load()
         if self._meta.total_supply is None:
             self._meta.total_supply = self.try_erc20_property('totalSupply')
         return self._meta.total_supply
 
-    def scaled(self, value):
+    def scaled(self, value) -> float:
         return value / (10 ** self.decimals)
 
 

--- a/credmark/cmf/types/token.py
+++ b/credmark/cmf/types/token.py
@@ -97,6 +97,7 @@ class Token(Contract):
 
     @property
     def info(self):
+        _ = self.symbol, self.name, self.decimals, self.total_supply
         if isinstance(self, TokenInfo):
             return self
         self._load()

--- a/credmark/cmf/types/token.py
+++ b/credmark/cmf/types/token.py
@@ -115,12 +115,16 @@ class Token(Contract):
         return prop_value
 
     @property
-    def symbol(self):
+    def symbol(self) -> str:
         self._load()
         if self._meta.symbol is None:
             symbol_tmp = self.try_erc20_property('symbol')
             if isinstance(symbol_tmp, bytes):
                 symbol_tmp = symbol_tmp.decode('utf-8', errors='strict').replace('\x00', '')
+            elif isinstance(symbol_tmp, str):
+                pass
+            else:
+                raise ModelDataError(f'Unknown value for symbol {symbol_tmp}')
             self._meta.symbol = symbol_tmp
         return self._meta.symbol
 


### PR DESCRIPTION
- Added return types for Token's methods. Improving from previous commit, `.name()`/`.symbol()` could return None and causes type checks flagging.
- Remove type hints of `dict` for `models.__call__()` as it could return DTO now.