### PR TITLE
Remove json output formatting

### DIFF
--- a/credmark/cmf/credmark_dev.py
+++ b/credmark/cmf/credmark_dev.py
@@ -555,7 +555,7 @@ def run_model(args):  # pylint: disable=too-many-statements,too-many-branches,to
             elif args['output']:
                 logger.info(f"Saving model results to {args['output']}")
                 with open(args['output'], 'w') as fp:
-                    json.dump(result, fp, indent=4)
+                    json.dump(result, fp)
             else:
                 json_dump(result, sys.stdout)
 


### PR DESCRIPTION
Previous formatting output causes data loading issues in snowflake. It's easy to format the JSON in a code editor if necessary so default output should not be formatted for you.